### PR TITLE
Add option for bootstrapped effect sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Evident is a tool for performing effect size and power calculations on microbiom
 
 You can install the most up-to-date version of Evident from PyPi using the following command:
 
-```bash
+```
 pip install evident
 ```
 
@@ -21,13 +21,13 @@ Make sure you have activated a QIIME 2 environment and run the same installation
 
 To check that Evident installed correctly, run the following from the command line:
 
-```bash
+```
 qiime evident --help
 ```
 
 You should see something like this if Evident installed correctly:
 
-```bash
+```
 Usage: qiime evident [OPTIONS] COMMAND [ARGS]...
 
   Description: Perform power analysis on microbiome data. Supports
@@ -167,7 +167,7 @@ create_bokeh_app(adh, "app")
 This will save the necessary files into a new directory `app/`.
 Navigate to the directory containing `app/` (**not** `app/` itself) and execute this command from your terminal:
 
-```bash
+```
 bokeh serve --show app
 ```
 
@@ -198,7 +198,7 @@ If you are using a different version and encounter an error please let us know v
 
 To calculate power, we can run the following command:
 
-```bash
+```
 qiime evident univariate-power-analysis \
     --m-sample-metadata-file metadata.qza \
     --m-sample-metadata-file faith_pd.qza \
@@ -220,7 +220,7 @@ In our example, we used `seq` to generate the values from 10 to 100 in intervals
 With this results artifact, we can visualize the power curve to get a sense of how power varies with number of observations and significance level.
 Run the following command:
 
-```bash
+```
 qiime evident plot-power-curve \
     --i-power-analysis-results results.qza \
     --p-target-power 0.8 \
@@ -251,7 +251,7 @@ effect_size_by_category(
 
 With QIIME 2:
 
-```bash
+```
 qiime evident univariate-effect-size-by-category \
     --m-sample-metadata-file metadata.qza \
     --m-sample-metadata-file faith_pd.qza \
@@ -259,6 +259,21 @@ qiime evident univariate-effect-size-by-category \
     --p-group-columns classification sex cd_behavior \
     --p-n-jobs 2 \
     --o-effect-size-results alpha_effect_sizes.qza
+```
+
+## Bootstrapped Effect Sizes
+
+Evident also allows calculation of bootstrapped effect sizes intervals.
+By providing the `bootstrap_iterations` parameter, you can shuffle the metadata with replacement and calculate the 2.5% and 97.5% quantiles.
+
+```python
+adh.calculate_effect_size("classification", bootstrap_iterations=1000)
+```
+
+This will return a result that includes `lower_es`, `upper_es`, and `iterations`.
+
+```
+EffectSizeResult(effect_size=1.0311033633149995, metric='cohens_d', column='classification', difference=None, lower_es=0.7960440465305569, upper_es=1.2986795949364291, iterations=1000)
 ```
 
 ## Repeated Measures

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -112,8 +112,12 @@ class _BaseDataHandler(ABC):
         if bootstrap_iterations is None:
             return result
 
+        # Assign original index so we can properly index distance matrix
         metadata_iter = iter(
-            self.metadata.sample(frac=1, replace=True)
+            (
+                self.metadata
+                .sample(frac=1, replace=True)
+            )
             for i in range(bootstrap_iterations)
         )
 
@@ -134,8 +138,8 @@ class _BaseDataHandler(ABC):
         )
 
         lower, upper = np.quantile(boot, [0.025, 0.975])
-        result.lower = lower
-        result.upper = upper
+        result.lower_es = lower
+        result.upper_es = upper
         result.iterations = bootstrap_iterations
 
         return result
@@ -190,7 +194,8 @@ class _BaseDataHandler(ABC):
         # Create list of arrays for effect size calculation
         arrays = []
         for choice in column_choices:
-            ids = metadata[metadata[column] == choice].index
+            # Set-ify so bootstrapping doesn't result in duplicate IDs
+            ids = list(set(metadata[metadata[column] == choice].index))
             values = self.subset_values(ids)
             arrays.append(values)
 

--- a/evident/effect_size.py
+++ b/evident/effect_size.py
@@ -30,6 +30,11 @@ def effect_size_by_category(
     :param columns: Columns to use for effect size calculations
     :type columns: List[str]
 
+    :param bootstrap_iterations: Number of iterations to shuffle data
+        for generating confidence interval. By default does not perform
+        bootstrapping.
+    :type bootstrap_iterations: int
+
     :param n_jobs: Number of jobs to run in parallel, defaults to None (single
         CPU)
     :type n_jobs: int
@@ -79,6 +84,11 @@ def pairwise_effect_size_by_category(
 
     :param columns: Columns to use for effect size calculations
     :type columns: List[str]
+
+    :param bootstrap_iterations: Number of iterations to shuffle data
+        for generating confidence interval. By default does not perform
+        bootstrapping.
+    :type bootstrap_iterations: int
 
     :param n_jobs: Number of jobs to run in parallel, defaults to None (single
         CPU)

--- a/evident/effect_size.py
+++ b/evident/effect_size.py
@@ -123,6 +123,7 @@ def _pw_column(dh, col):
         vals1 = values_dict[grp1]
         vals2 = values_dict[grp2]
         effect_size = calculate_cohens_d(vals1, vals2)
-        res = PairwiseEffectSizeResult(effect_size, col, grp1, grp2)
+        res = PairwiseEffectSizeResult(effect_size, "cohens_d", col,
+                                       group_1=grp1, group_2=grp2)
         col_results.append(res)
     return col_results

--- a/evident/effect_size.py
+++ b/evident/effect_size.py
@@ -124,6 +124,7 @@ def _pw_column(dh, col):
         vals2 = values_dict[grp2]
         effect_size = calculate_cohens_d(vals1, vals2)
         res = PairwiseEffectSizeResult(effect_size, "cohens_d", col,
+                                       difference=None,
                                        group_1=grp1, group_2=grp2)
         col_results.append(res)
     return col_results

--- a/evident/plotting.py
+++ b/evident/plotting.py
@@ -48,4 +48,5 @@ def plot_power_curve(
     ax.set_axisbelow(True)
     ax.set_ylabel(r"Power (1 - $\beta$)", fontsize="large")
     ax.set_xlabel("Total Observations", fontsize="large")
+
     return ax

--- a/evident/q2/_methods.py
+++ b/evident/q2/_methods.py
@@ -79,7 +79,8 @@ def univariate_effect_size_by_category(
     pairwise: bool = False,
     n_jobs: int = None,
     max_levels_per_category: int = 5,
-    min_count_per_level: int = 3
+    min_count_per_level: int = 3,
+    bootstrap_iterations: int = None
 ) -> pd.DataFrame:
     sample_metadata = sample_metadata.to_dataframe()
     _check_provided_univariate_data(sample_metadata, data_column)
@@ -89,7 +90,8 @@ def univariate_effect_size_by_category(
     res = _effect_size_by_category(data, sample_metadata,
                                    UnivariateDataHandler, group_columns,
                                    pairwise, n_jobs, max_levels_per_category,
-                                   min_count_per_level)
+                                   min_count_per_level,
+                                   bootstrap_iterations)
     return res
 
 
@@ -100,25 +102,31 @@ def multivariate_effect_size_by_category(
     pairwise: bool = False,
     n_jobs: int = None,
     max_levels_per_category: int = 5,
-    min_count_per_level: int = 3
+    min_count_per_level: int = 3,
+    bootstrap_iterations: int = None
 ) -> pd.DataFrame:
     sample_metadata = sample_metadata.to_dataframe()
     res = _effect_size_by_category(data, sample_metadata,
                                    MultivariateDataHandler, group_columns,
                                    pairwise, n_jobs, max_levels_per_category,
-                                   min_count_per_level)
+                                   min_count_per_level,
+                                   bootstrap_iterations)
     return res
 
 
 def _effect_size_by_category(data, metadata, handler, columns, pairwise,
                              n_jobs, max_levels_per_category,
-                             min_count_per_level):
+                             min_count_per_level,
+                             bootstrap_iterations):
     dh = handler(data, metadata, max_levels_per_category,
                  min_count_per_level)
     if pairwise:
-        res = pairwise_effect_size_by_category(dh, columns, n_jobs=n_jobs)
+        func = pairwise_effect_size_by_category
     else:
-        res = effect_size_by_category(dh, columns, n_jobs=n_jobs)
+        func = effect_size_by_category
+
+    res = func(dh, columns, n_jobs=n_jobs,
+               bootstrap_iterations=bootstrap_iterations)
     return res.to_dataframe()
 
 

--- a/evident/q2/plugin_setup.py
+++ b/evident/q2/plugin_setup.py
@@ -70,6 +70,11 @@ ES_PARAM_DESCS = {
         "Min number of samples in a given category level to keep. Any levels "
         "that have fewer than this many samples will not be saved, defaults "
         "to 3."
+    ),
+    "bootstrap_iterations": (
+        "Number of reshuffles of the data to use to generate confidence "
+        "interval of effect size(s). By default does not do any "
+        "bootstrapping."
     )
 }
 
@@ -193,7 +198,8 @@ plugin.methods.register_function(
         "pairwise": Bool,
         "n_jobs": Int,
         "max_levels_per_category": Int,
-        "min_count_per_level": Int
+        "min_count_per_level": Int,
+        "bootstrap_iterations": Int
     },
     parameter_descriptions=ES_PARAM_DESCS,
     outputs=[("effect_size_results", EffectSizeResults)],
@@ -214,7 +220,8 @@ plugin.methods.register_function(
         "pairwise": Bool,
         "n_jobs": Int,
         "max_levels_per_category": Int,
-        "min_count_per_level": Int
+        "min_count_per_level": Int,
+        "bootstrap_iterations": Int
     },
     parameter_descriptions=ES_PARAM_DESCS,
     outputs=[("effect_size_results", EffectSizeResults)],

--- a/evident/q2/tests/test_plugin.py
+++ b/evident/q2/tests/test_plugin.py
@@ -162,6 +162,19 @@ def test_multivariate_effect_size_by_cat_parallel(beta_artifact, metadata):
     assert (pairwise.columns == exp_cols).all()
 
 
+def test_bootstrap(alpha_artifact, metadata_w_data):
+    non_pairwise = evident.methods.univariate_effect_size_by_category(
+        sample_metadata=metadata_w_data,
+        data_column="alpha_div",
+        group_columns=["classification", "cd_behavior"],
+        n_jobs=2,
+        bootstrap_iterations=100
+    ).effect_size_results.view(pd.DataFrame)
+    for i, row in non_pairwise.iterrows():
+        assert row["lower_es"] < row["effect_size"] < row["upper_es"]
+        assert row["iterations"] == 100
+
+
 def test_visualize_es_results(es_results):
     evident.visualizers.visualize_results(results=es_results)
 

--- a/evident/results.py
+++ b/evident/results.py
@@ -10,8 +10,8 @@ class EffectSizeResult:
     metric: str
     column: str
     difference: float
-    lower: float = field(default=None, init=False)
-    upper: float = field(default=None, init=False)
+    lower_es: float = field(default=None, init=False)
+    upper_es: float = field(default=None, init=False)
     iterations: int = field(default=None, init=False)
 
     def to_dict(self) -> dict:

--- a/evident/results.py
+++ b/evident/results.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field, asdict
 from typing import Any, List
 
 import pandas as pd
@@ -9,27 +9,20 @@ class EffectSizeResult:
     effect_size: float
     metric: str
     column: str
+    lower: float = field(default=None, init=False)
+    upper: float = field(default=None, init=False)
+    iterations: int = field(default=None, init=False)
 
     def to_dict(self) -> dict:
-        res_dict = {
-            "effect_size": self.effect_size,
-            "metric": self.metric,
-            "column": self.column,
-        }
-        return res_dict
+        d = asdict(self)
+        d = {k: v for k, v in d.items() if v is not None}
+        return d
 
 
+@dataclass
 class PairwiseEffectSizeResult(EffectSizeResult):
-    def __init__(self, value: float, column: str, group_1: str, group_2: str):
-        self.group_1 = group_1
-        self.group_2 = group_2
-        super().__init__(value, "cohens_d", column)
-
-    def to_dict(self) -> dict:
-        res_dict = super().to_dict()
-        res_dict["group_1"] = self.group_1
-        res_dict["group_2"] = self.group_2
-        return res_dict
+    group_1: str
+    group_2: str
 
 
 @dataclass

--- a/evident/results.py
+++ b/evident/results.py
@@ -9,6 +9,7 @@ class EffectSizeResult:
     effect_size: float
     metric: str
     column: str
+    difference: float
     lower: float = field(default=None, init=False)
     upper: float = field(default=None, init=False)
     iterations: int = field(default=None, init=False)
@@ -26,38 +27,23 @@ class PairwiseEffectSizeResult(EffectSizeResult):
 
 
 @dataclass
-class _PowerAnalysisResult:
+class PowerAnalysisResult:
     alpha: float
     total_observations: int
     power: float
     effect_size_result: EffectSizeResult
 
     def to_dict(self) -> dict:
-        res_dict = {
-            "alpha": self.alpha,
-            "total_observations": self.total_observations,
-            "power": self.power,
-            "effect_size": self.effect_size_result,
-        }
+        res_dict = dict()
+        res_dict["alpha"] = self.alpha
+        res_dict["total_observations"] = self.total_observations
+        res_dict["power"] = self.power
+        res_dict["effect_size"] = self.effect_size_result
         return res_dict
 
 
 @dataclass
-class CrossSectionalPowerAnalysisResult(_PowerAnalysisResult):
-    alpha: float
-    total_observations: int
-    power: float
-    effect_size_result: EffectSizeResult
-    difference: float
-
-    def to_dict(self) -> dict:
-        res_dict = super().to_dict()
-        res_dict["difference"] = self.difference
-        return res_dict
-
-
-@dataclass
-class RepeatedMeasuresPowerAnalysisResult(_PowerAnalysisResult):
+class RepeatedMeasuresPowerAnalysisResult(PowerAnalysisResult):
     alpha: float
     power: float
     effect_size_result: EffectSizeResult
@@ -107,7 +93,7 @@ class _EvidentResults:
 
 
 class PowerAnalysisResults(_EvidentResults):
-    def __init__(self, results: List[_PowerAnalysisResult]):
+    def __init__(self, results: List[PowerAnalysisResult]):
         super().__init__(results)
 
     def to_dataframe(self):

--- a/evident/tests/test_bootstrap.py
+++ b/evident/tests/test_bootstrap.py
@@ -1,7 +1,7 @@
 def test_bootstrap(alpha_mock):
-    boot_es = alpha_mock.calculate_bootstrapped_effect_size(
+    boot_es = alpha_mock.calculate_effect_size(
         column="classification",
-        iterations=1000
+        bootstrap_iterations=1000
     )
     assert boot_es.lower < boot_es.effect_size < boot_es.upper
     assert boot_es.iterations == 1000

--- a/evident/tests/test_bootstrap.py
+++ b/evident/tests/test_bootstrap.py
@@ -1,0 +1,7 @@
+def test_bootstrap(alpha_mock):
+    boot_es = alpha_mock.calculate_bootstrapped_effect_size(
+        column="classification",
+        iterations=1000
+    )
+    assert boot_es.lower < boot_es.effect_size < boot_es.upper
+    assert boot_es.iterations == 1000

--- a/evident/tests/test_bootstrap.py
+++ b/evident/tests/test_bootstrap.py
@@ -1,7 +1,40 @@
-def test_bootstrap(alpha_mock):
+from evident.effect_size import (effect_size_by_category,
+                                 pairwise_effect_size_by_category)
+
+
+def test_bootstrap_alpha(alpha_mock):
     boot_es = alpha_mock.calculate_effect_size(
         column="classification",
-        bootstrap_iterations=1000
+        bootstrap_iterations=100
     )
-    assert boot_es.lower < boot_es.effect_size < boot_es.upper
-    assert boot_es.iterations == 1000
+    assert boot_es.lower_es < boot_es.effect_size < boot_es.upper_es
+    assert boot_es.iterations == 100
+
+
+def test_bootstrap_beta(beta_mock):
+    boot_es = beta_mock.calculate_effect_size(
+        column="classification",
+        bootstrap_iterations=100
+    )
+    assert boot_es.lower_es < boot_es.effect_size < boot_es.upper_es
+    assert boot_es.iterations == 100
+
+
+def test_es_by_category_bootstrap(alpha_mock):
+    boot_res = effect_size_by_category(
+        alpha_mock,
+        ["classification", "cd_resection"],
+        bootstrap_iterations=100
+    )
+    for es in boot_res:
+        assert es.lower_es < es.effect_size < es.upper_es
+
+
+def test_pw_es_by_category_bootstrap(alpha_mock):
+    boot_res = pairwise_effect_size_by_category(
+        alpha_mock,
+        ["cd_behavior", "ibd_subtype"],
+        bootstrap_iterations=100
+    )
+    for es in boot_res:
+        assert es.lower_es < es.effect_size < es.upper_es

--- a/evident/tests/test_data_handler.py
+++ b/evident/tests/test_data_handler.py
@@ -217,7 +217,7 @@ class TestPower:
         exp_power = 0.775732
         np.testing.assert_almost_equal(calc_power, exp_power, decimal=6)
 
-    def test_beta_power_power_t(self, beta_mock):
+    def test_beta_power_t(self, beta_mock):
         calc_power = beta_mock.power_analysis(
             "classification",
             total_observations=40,


### PR DESCRIPTION
Closes #18

Adds option to provide parameter `bootstrap_iterations` to calculate bootstrapped CIs. Reshuffles data with replacement to generate 95% CI.

Also refactors some of the `DataHandler` internals to clean up code. CC @dhakim87 who had the idea for the reorganization of `_bulk_power_analysis` such that we can drop the LRU caching.

TODO: Update docstrings