### PR TITLE
Add PERMANOVA effect size support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - develop
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/q2.yml
+++ b/.github/workflows/q2.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - develop
   push:
     branches:
       - master
+      - develop
 
 jobs:
   build:

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -857,7 +857,7 @@ class MultivariateDataHandler(_BaseDataHandler):
         :param permutations: Number of bootstrap permutations to perform.
         :type permuations: int
         """
-        num_groups = len(self.metadata[column].unique())
+        num_groups = len(self.metadata[column].dropna().unique())
 
         # Convert DM to DataFrame to handle duplicate IDs
         omega_sq = self._calculate_permanova_vals(

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -897,9 +897,8 @@ class MultivariateDataHandler(_BaseDataHandler):
         alpha: float,
         permutations: int
     ) -> float:
-        group_size = total_observations // num_groups
-
         # In case total_observations is not evenly divisible
+        group_size = round(total_observations / num_groups)
         total_observations = num_groups * group_size
 
         condensed_distances = self.data.to_data_frame()

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -859,6 +859,7 @@ class MultivariateDataHandler(_BaseDataHandler):
         """
         num_groups = len(self.metadata[column].unique())
 
+        # Convert DM to DataFrame to handle duplicate IDs
         omega_sq = self._calculate_permanova_vals(
             self.data.to_data_frame(),
             column,

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -16,7 +16,8 @@ from .results import (PowerAnalysisResult, PowerAnalysisResults,
 from .stats import (calculate_cohens_d, calculate_cohens_f,
                     calculate_pooled_stdev, calculate_eta_squared,
                     calculate_rm_anova_power, _calculate_permanova_omsq)
-from .utils import _listify, _check_sample_overlap, _preprocess_input
+from .utils import (_listify, _check_sample_overlap, _preprocess_input,
+                    _check_total_observations)
 
 
 class _BaseDataHandler(ABC):
@@ -283,6 +284,9 @@ class _BaseDataHandler(ABC):
         none_args = [x is None for x in args]
         if sum(none_args) != 1:  # Check to make sure exactly one arg is None
             raise exc.WrongPowerArguments(*args)
+        if total_observations is not None:
+            for obs in _listify(total_observations):
+                _check_total_observations(self.metadata, column, obs)
 
         # If any of the arguments are iterable, perform power analysis on
         #     all possible argument combinations. Otherwise, perform a single
@@ -897,6 +901,8 @@ class MultivariateDataHandler(_BaseDataHandler):
         alpha: float,
         permutations: int
     ) -> float:
+        _check_total_observations(self.metadata, column, total_observations)
+
         # In case total_observations is not evenly divisible
         group_size = round(total_observations / num_groups)
         total_observations = num_groups * group_size

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -23,7 +23,7 @@ class _BaseDataHandler(ABC):
     """Abstract class for handling data and metadata."""
     def __init__(
         self,
-        data=None,
+        data = None,
         metadata: pd.DataFrame = None,
         max_levels_per_category: int = 5,
         min_count_per_level: int = 3,

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -8,7 +8,6 @@ from joblib import Parallel, delayed
 import numpy as np
 import pandas as pd
 from skbio import DistanceMatrix
-from skbio.stats.distance._base import _preprocess_input
 from statsmodels.stats.power import tt_ind_solve_power, FTestAnovaPower
 
 from . import _exceptions as exc
@@ -17,7 +16,7 @@ from .results import (PowerAnalysisResult, PowerAnalysisResults,
 from .stats import (calculate_cohens_d, calculate_cohens_f,
                     calculate_pooled_stdev, calculate_eta_squared,
                     calculate_rm_anova_power, _calculate_permanova_omsq)
-from .utils import _listify, _check_sample_overlap
+from .utils import _listify, _check_sample_overlap, _preprocess_input
 
 
 class _BaseDataHandler(ABC):
@@ -755,9 +754,14 @@ class MultivariateDataHandler(_BaseDataHandler):
                 parallel_args=parallel_args
             )
 
+        # Convert here so bootstrap is easier for duplicate samples
+        # As dm.filter doesn't allow duplicates
+        dm = self.data.to_data_frame()
+        distances = self.data.condensed_form()
+
         sample_size, num_groups, grouping, tri_idxs, distances = (
             _preprocess_input(
-                self.data,
+                dm,
                 self.metadata,
                 column
             )
@@ -773,5 +777,44 @@ class MultivariateDataHandler(_BaseDataHandler):
         metric = "omega_squared"
         result = EffectSizeResult(effect_size=es, metric=metric, column=column,
                                   difference=None)
+
+        if bootstrap_iterations is None:
+            return result
+
+        metadata_iter = iter(
+            self.metadata.sample(frac=1, replace=True)
+            for i in range(bootstrap_iterations)
+        )
+
+        def _bootstrap(metadata):
+            sample_size, num_groups, grouping, tri_idxs, distances = (
+                _preprocess_input(
+                    dm,
+                    metadata,
+                    column
+                )
+            )
+
+            boot_es = _calculate_permanova_omsq(
+                sample_size,
+                num_groups,
+                tri_idxs,
+                distances,
+                grouping
+            )
+            return boot_es
+
+        if parallel_args is None:
+            parallel_args = dict()
+
+        boot = Parallel(n_jobs=n_jobs, **parallel_args)(
+            delayed(_bootstrap)(metadata)
+            for metadata in metadata_iter
+        )
+
+        lower, upper = np.quantile(boot, [0.025, 0.975])
+        result.lower_es = lower
+        result.upper_es = upper
+        result.iterations = bootstrap_iterations
 
         return result

--- a/evident/data_handler.py
+++ b/evident/data_handler.py
@@ -810,6 +810,8 @@ class MultivariateDataHandler(_BaseDataHandler):
         column: str,
         metadata: pd.DataFrame,
     ):
+        # Take distance_matrix as DataFrame so we can have repeated IDs that
+        # arise from subsampling with replacement.
         sample_size, num_groups, grouping, tri_idxs, distances = (
             _preprocess_input(
                 distance_matrix,

--- a/evident/effect_size.py
+++ b/evident/effect_size.py
@@ -60,8 +60,9 @@ def effect_size_by_category(
                 "Ignoring for provided univariate data."
             )
             warn(warn_msg, UserWarning)
+            func = dh.calculate_effect_size
         else:
-            func = partial(dh.calculate_effect_size, permanova=True)
+            func = partial(dh.calculate_effect_size, permanova=permanova)
     else:
         func = dh.calculate_effect_size
 

--- a/evident/q2/_methods.py
+++ b/evident/q2/_methods.py
@@ -1,4 +1,5 @@
 from typing import List
+from functools import partial
 
 import pandas as pd
 from qiime2 import Metadata
@@ -99,6 +100,7 @@ def multivariate_effect_size_by_category(
     data: DistanceMatrix,
     sample_metadata: Metadata,
     group_columns: List[str],
+    permanova: bool = False,
     pairwise: bool = False,
     n_jobs: int = None,
     max_levels_per_category: int = 5,
@@ -109,21 +111,28 @@ def multivariate_effect_size_by_category(
     res = _effect_size_by_category(data, sample_metadata,
                                    MultivariateDataHandler, group_columns,
                                    pairwise, n_jobs, max_levels_per_category,
-                                   min_count_per_level,
-                                   bootstrap_iterations)
+                                   min_count_per_level, bootstrap_iterations,
+                                   permanova)
     return res
 
 
 def _effect_size_by_category(data, metadata, handler, columns, pairwise,
                              n_jobs, max_levels_per_category,
                              min_count_per_level,
-                             bootstrap_iterations):
+                             bootstrap_iterations, permanova=False):
     dh = handler(data, metadata, max_levels_per_category,
                  min_count_per_level)
     if pairwise:
+        if permanova:
+            msg = (
+                "Currently PERMANOVA is not supported for pairwise "
+                "comparisons."
+            )
+            raise ValueError(msg)
+
         func = pairwise_effect_size_by_category
     else:
-        func = effect_size_by_category
+        func = partial(effect_size_by_category, permanova=True)
 
     res = func(dh, columns, n_jobs=n_jobs,
                bootstrap_iterations=bootstrap_iterations)

--- a/evident/q2/_methods.py
+++ b/evident/q2/_methods.py
@@ -65,6 +65,28 @@ def multivariate_power_analysis(
     return res
 
 
+def multivariate_power_analysis_permanova(
+    data: DistanceMatrix,
+    sample_metadata: Metadata,
+    group_column: str,
+    total_observations: list = None,
+    max_levels_per_category: int = 5,
+    min_count_per_level: int = 3,
+    alpha: list = [0.05],
+    permutations: int = 999
+) -> pd.DataFrame:
+    sample_metadata = sample_metadata.to_dataframe()
+    mdh = MultivariateDataHandler(data, sample_metadata,
+                                  max_levels_per_category, min_count_per_level)
+    res = mdh.power_analysis_permanova(
+        group_column,
+        total_observations,
+        alpha,
+        permutations
+    )
+    return res.to_dataframe()
+
+
 def _power_analysis(data, metadata, group_column, handler,
                     max_levels_per_category, min_count_per_level, **kwargs):
     dh = handler(data, metadata, max_levels_per_category,

--- a/evident/q2/plugin_setup.py
+++ b/evident/q2/plugin_setup.py
@@ -210,6 +210,11 @@ plugin.methods.register_function(
     )
 )
 
+mult_es_params = ES_PARAM_DESCS.copy()
+mult_es_params["permanova"] = (
+    "Whether to evaluate differences in within-group distances (default) "
+    "or PERMANOVA."
+)
 plugin.methods.register_function(
     function=multivariate_effect_size_by_category,
     inputs={"data": DistanceMatrix},
@@ -218,12 +223,13 @@ plugin.methods.register_function(
         "sample_metadata": Metadata,
         "group_columns": List[Str],
         "pairwise": Bool,
+        "permanova": Bool,
         "n_jobs": Int,
         "max_levels_per_category": Int,
         "min_count_per_level": Int,
         "bootstrap_iterations": Int
     },
-    parameter_descriptions=ES_PARAM_DESCS,
+    parameter_descriptions=mult_es_params,
     outputs=[("effect_size_results", EffectSizeResults)],
     name="Multivariate data effect size by category.",
     description=(

--- a/evident/q2/plugin_setup.py
+++ b/evident/q2/plugin_setup.py
@@ -11,6 +11,7 @@ from ._type import PowerAnalysisResults, EffectSizeResults
 from ._methods import (univariate_power_analysis, multivariate_power_analysis,
                        univariate_effect_size_by_category,
                        multivariate_effect_size_by_category,
+                       multivariate_power_analysis_permanova,
                        univariate_power_analysis_repeated_measures)
 from ._visualizers import plot_power_curve, visualize_results
 
@@ -235,6 +236,34 @@ plugin.methods.register_function(
     description=(
         "Calculate multivariate data difference effect size of multiple "
         "categories."
+    )
+)
+
+perm_pa_param_descs = {
+    k: v for k, v in PA_PARAM_DESCS.items()
+    if k not in ["power", "difference"]
+}
+perm_pa_param_descs["permutations"] = (
+    "Bootstrap permutations to use when calculating power."
+)
+plugin.methods.register_function(
+    function=multivariate_power_analysis_permanova,
+    inputs={"data": DistanceMatrix},
+    input_descriptions={"data": "Multivariate data distance matrix"},
+    parameters={
+        "sample_metadata": Metadata,
+        "group_column": Str,
+        "max_levels_per_category": Int,
+        "min_count_per_level": Int,
+        "permutations": Int,
+        "alpha": List[Probability],
+        "total_observations": List[Int],
+    },
+    parameter_descriptions=perm_pa_param_descs,
+    outputs=[("power_analysis_results", PowerAnalysisResults)],
+    name="Multivariate PERMANOVA power analysis.",
+    description=(
+        "Calculate multivariate PERMANOVA power analysis using bootstrapping."
     )
 )
 

--- a/evident/q2/tests/test_plugin.py
+++ b/evident/q2/tests/test_plugin.py
@@ -117,6 +117,18 @@ def test_multivariate_effect_size_by_cat(beta_artifact, metadata):
     assert (pairwise.columns == exp_cols).all()
 
 
+def test_multivariate_effect_size_by_cat_perm(beta_artifact, metadata):
+    non_pairwise = evident.methods.multivariate_effect_size_by_category(
+        data=beta_artifact,
+        sample_metadata=metadata,
+        permanova=True,
+        group_columns=["classification", "cd_behavior"]
+    ).effect_size_results.view(pd.DataFrame)
+    assert (non_pairwise["metric"] == "omega_squared").all()
+    assert non_pairwise.shape == (2, 3)
+    assert (non_pairwise.columns == ["effect_size", "metric", "column"]).all()
+
+
 def test_univariate_effect_size_by_cat_parallel(alpha_artifact,
                                                 metadata_w_data):
     non_pairwise = evident.methods.univariate_effect_size_by_category(

--- a/evident/q2/tests/test_plugin.py
+++ b/evident/q2/tests/test_plugin.py
@@ -129,6 +129,30 @@ def test_multivariate_effect_size_by_cat_perm(beta_artifact, metadata):
     assert (non_pairwise.columns == ["effect_size", "metric", "column"]).all()
 
 
+def test_multivariate_power_analysis_perm(beta_artifact, metadata):
+    pa_results = evident.methods.multivariate_power_analysis_permanova(
+        data=beta_artifact,
+        sample_metadata=metadata,
+        group_column="sex",
+        total_observations=[25, 50, 75],
+    ).power_analysis_results.view(pd.DataFrame)
+    assert (pa_results["metric"] == "omega_sq").all()
+    assert pa_results.shape == (3, 6)
+    exp_cols = [
+        "alpha",
+        "total_observations",
+        "power",
+        "effect_size",
+        "metric",
+        "column"
+    ]
+    assert (pa_results.columns == exp_cols).all()
+    assert (pa_results["total_observations"] == [25, 50, 75]).all()
+    es = pa_results["power"].to_list()
+    sorted_es = sorted(es)
+    assert es == sorted_es
+
+
 def test_univariate_effect_size_by_cat_parallel(alpha_artifact,
                                                 metadata_w_data):
     non_pairwise = evident.methods.univariate_effect_size_by_category(

--- a/evident/stats.py
+++ b/evident/stats.py
@@ -211,8 +211,14 @@ def _calculate_permanova_omsq(
 ) -> float:
     """Calculate omega-squared for PERMANOVA.
 
-    Code adapted from scikit-bio.
-    Calculation adapted from
+    The code used for calculating PERMANOVA effect sizes is adapted from
+        the scikit-bio package (BSD-3). We modify this code because their
+        implementation does not expose the intermediate sums-of-squares
+        values necessary to calculate omega-squared.
+
+    Original scikit-bio code: https://tinyurl.com/4c82f4u7
+
+    Effect size calculation adapted from
         https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4514928/
 
     :param sample_size: Number of samples

--- a/evident/stats.py
+++ b/evident/stats.py
@@ -173,7 +173,7 @@ def calculate_rm_anova_power(
 def _calculate_permanova_omsq(
     sample_size: int,
     num_groups: int,
-    tri_idxs: np.ndarray,
+    tri_idxs: tuple,
     distances: np.ndarray,
     grouping: np.ndarray
 ) -> float:
@@ -182,6 +182,24 @@ def _calculate_permanova_omsq(
     Code adapted from scikit-bio.
     Calculation adapted from
         https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4514928/
+
+    :param sample_size: Number of samples
+    :type sample_size: int
+
+    :param num_groups: Number of factors
+    :type num_groups: int
+
+    :param_tri_idxs: Indices for upper-triangle
+    :type tri_idxs: (np.ndarray, np.ndarray)
+
+    :param distances: Vector of distances (condensed)
+    :type distances: np.ndarray
+
+    :param grouping: Mapping of groups
+    :type grouping: np.ndarray
+
+    :returns: Omega squared value
+    :rtype: float
     """
     group_sizes = np.bincount(grouping)
     s_T = (distances ** 2).sum() / sample_size

--- a/evident/stats.py
+++ b/evident/stats.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 import numpy as np
 import pandas as pd
 from scipy import stats

--- a/evident/stats.py
+++ b/evident/stats.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import numpy as np
 import pandas as pd
 from scipy import stats
@@ -170,6 +172,38 @@ def calculate_rm_anova_power(
     return power
 
 
+def _calculate_ss(
+    sample_size: int,
+    num_groups: int,
+    tri_idxs: tuple,
+    distances: np.ndarray,
+    grouping: np.ndarray
+) -> (float, float, float):
+    """Calculate sums of squares components."""
+    group_sizes = np.bincount(grouping)
+    s_T = (distances ** 2).sum() / sample_size
+    grouping_matrix = -1 * np.ones((sample_size, sample_size), dtype=int)
+
+    for group_idx in range(num_groups):
+        within_indices = _index_combinations(
+            np.where(grouping == group_idx)[0]
+        )
+        grouping_matrix[within_indices] = group_idx
+
+    # Extract upper triangle (in same order as distances were extracted
+    # from full distance matrix).
+    grouping_tri = grouping_matrix[tri_idxs]
+
+    # Calculate s_W for each group, accounting for different group sizes.
+    s_W = 0
+    for i in range(num_groups):
+        s_W += (distances[grouping_tri == i] ** 2).sum() / group_sizes[i]
+
+    s_A = s_T - s_W
+
+    return s_W, s_A, s_T
+
+
 def _calculate_permanova_omsq(
     sample_size: int,
     num_groups: int,
@@ -201,26 +235,15 @@ def _calculate_permanova_omsq(
     :returns: Omega squared value
     :rtype: float
     """
-    group_sizes = np.bincount(grouping)
-    s_T = (distances ** 2).sum() / sample_size
-    grouping_matrix = -1 * np.ones((sample_size, sample_size), dtype=int)
-    for group_idx in range(num_groups):
-        within_indices = _index_combinations(
-            np.where(grouping == group_idx)[0]
-        )
-        grouping_matrix[within_indices] = group_idx
-
-    # Extract upper triangle (in same order as distances were extracted
-    # from full distance matrix).
-    grouping_tri = grouping_matrix[tri_idxs]
-
-    # Calculate s_W for each group, accounting for different group sizes.
-    s_W = 0
-    for i in range(num_groups):
-        s_W += (distances[grouping_tri == i] ** 2).sum() / group_sizes[i]
-
-    s_A = s_T - s_W
+    s_W, s_A, s_T = _calculate_ss(sample_size, num_groups, tri_idxs,
+                                  distances, grouping)
     numerator = s_A - (num_groups - 1) * s_W / (sample_size - num_groups)
     denominator = s_T + s_W / (sample_size - num_groups)
 
-    return numerator / denominator
+    results = {
+        "s_W": s_W,
+        "s_A": s_A,
+        "s_T": s_T,
+        "omega_sq": numerator / denominator
+    }
+    return results

--- a/evident/stats.py
+++ b/evident/stats.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 from scipy import stats
-from skbio.stats.distance._permanova import _index_combinations
 
 
 def calculate_pooled_stdev(*arrays) -> float:
@@ -251,3 +250,14 @@ def _calculate_permanova_omsq(
         "omega_sq": numerator / denominator
     }
     return results
+
+
+def _index_combinations(indices):
+    """Cartesian product of arrays.
+
+    Reproduced from scikit-bio under BSD-3 since this function is
+    deprecated in future versions (need here for older Q2 compatibility).
+
+    Original code: https://tinyurl.com/bdzb6jut
+    """
+    return np.tile(indices, len(indices)), np.repeat(indices, len(indices))

--- a/evident/tests/test_permanova.py
+++ b/evident/tests/test_permanova.py
@@ -69,26 +69,16 @@ def test_permanova_es_by_cat_boot(beta_mock):
     assert res_2.lower_es.item() < res_2.effect_size.item()
 
 
-def test_permanova2(beta_mock):
+def test_permanova_power(beta_mock):
     mdh = beta_mock
-    result_1 = mdh.calculate_effect_size("sex", permanova=True)
-    print(result_1)
-
-    from skbio.stats.distance import permanova
-    result_2 = permanova(mdh.data, mdh.metadata, "sex")
-    print(result_2)
-
-    assert 0
-
-
-def test_permanova3(beta_mock):
-    mdh = beta_mock
-    # result_1 = mdh.calculate_effect_size("sex", permanova=True)
     result_1 = mdh.power_analysis_permanova(
-        "cd_behavior",
-        total_observations=30,
-        alpha=0.01
-    )
-    print(result_1)
+        "sex",
+        total_observations=[25, 50, 75, 100],
+        alpha=0.01,
+        permutations=999
+    ).to_dataframe()
 
-    assert 0
+    power_vec = result_1["effect_size"].to_list()
+    power_vec_sorted = sorted(power_vec)
+
+    assert power_vec == power_vec_sorted

--- a/evident/tests/test_permanova.py
+++ b/evident/tests/test_permanova.py
@@ -13,6 +13,8 @@ def test_permanova(beta_mock):
     exp_2 = 0.081102
     np.testing.assert_approx_equal(exp_2, result_2.effect_size, 5)
 
+    assert 0
+
 
 def test_boot_permanova(beta_mock):
     mdh = beta_mock
@@ -65,3 +67,28 @@ def test_permanova_es_by_cat_boot(beta_mock):
     np.testing.assert_approx_equal(exp_2, res_2["effect_size"], 5)
     assert res_2.upper_es.item() > res_2.effect_size.item()
     assert res_2.lower_es.item() < res_2.effect_size.item()
+
+
+def test_permanova2(beta_mock):
+    mdh = beta_mock
+    result_1 = mdh.calculate_effect_size("sex", permanova=True)
+    print(result_1)
+
+    from skbio.stats.distance import permanova
+    result_2 = permanova(mdh.data, mdh.metadata, "sex")
+    print(result_2)
+
+    assert 0
+
+
+def test_permanova3(beta_mock):
+    mdh = beta_mock
+    # result_1 = mdh.calculate_effect_size("sex", permanova=True)
+    result_1 = mdh.power_analysis_permanova(
+        "cd_behavior",
+        total_observations=30,
+        alpha=0.01
+    )
+    print(result_1)
+
+    assert 0

--- a/evident/tests/test_permanova.py
+++ b/evident/tests/test_permanova.py
@@ -1,4 +1,5 @@
 import numpy as np
+from evident.effect_size import effect_size_by_category
 
 
 def test_permanova(beta_mock):
@@ -11,3 +12,56 @@ def test_permanova(beta_mock):
 
     exp_2 = 0.081102
     np.testing.assert_approx_equal(exp_2, result_2.effect_size, 5)
+
+
+def test_boot_permanova(beta_mock):
+    mdh = beta_mock
+    result_1 = mdh.calculate_effect_size("classification", permanova=True,
+                                         bootstrap_iterations=50)
+    result_2 = mdh.calculate_effect_size("cd_behavior", permanova=True,
+                                         bootstrap_iterations=50)
+
+    exp_1 = 0.074407
+    np.testing.assert_approx_equal(exp_1, result_1.effect_size, 5)
+    assert result_1.upper_es > result_1.effect_size
+    assert result_1.lower_es < result_1.effect_size
+
+    exp_2 = 0.081102
+    np.testing.assert_approx_equal(exp_2, result_2.effect_size, 5)
+    assert result_2.upper_es > result_2.effect_size
+    assert result_2.lower_es < result_2.effect_size
+
+
+def test_permanova_es_by_cat(beta_mock):
+    mdh = beta_mock
+    cols = ["classification", "cd_behavior"]
+    result = effect_size_by_category(mdh, cols, permanova=True)
+    result = result.to_dataframe()
+
+    exp_1 = 0.074407
+    res_1 = result.query("column == 'classification'")["effect_size"]
+    np.testing.assert_approx_equal(exp_1, res_1, 5)
+
+    exp_2 = 0.081102
+    res_2 = result.query("column == 'cd_behavior'")["effect_size"]
+    np.testing.assert_approx_equal(exp_2, res_2, 5)
+
+
+def test_permanova_es_by_cat_boot(beta_mock):
+    mdh = beta_mock
+    cols = ["classification", "cd_behavior"]
+    result = effect_size_by_category(mdh, cols, permanova=True,
+                                     bootstrap_iterations=50)
+    result = result.to_dataframe()
+
+    exp_1 = 0.074407
+    res_1 = result.query("column == 'classification'")
+    np.testing.assert_approx_equal(exp_1, res_1["effect_size"], 5)
+    assert res_1.upper_es.item() > res_1.effect_size.item()
+    assert res_1.lower_es.item() < res_1.effect_size.item()
+
+    exp_2 = 0.081102
+    res_2 = result.query("column == 'cd_behavior'")
+    np.testing.assert_approx_equal(exp_2, res_2["effect_size"], 5)
+    assert res_2.upper_es.item() > res_2.effect_size.item()
+    assert res_2.lower_es.item() < res_2.effect_size.item()

--- a/evident/tests/test_permanova.py
+++ b/evident/tests/test_permanova.py
@@ -13,8 +13,6 @@ def test_permanova(beta_mock):
     exp_2 = 0.081102
     np.testing.assert_approx_equal(exp_2, result_2.effect_size, 5)
 
-    assert 0
-
 
 def test_boot_permanova(beta_mock):
     mdh = beta_mock
@@ -74,11 +72,11 @@ def test_permanova_power(beta_mock):
     result_1 = mdh.power_analysis_permanova(
         "sex",
         total_observations=[25, 50, 75, 100],
-        alpha=0.01,
+        alpha=[0.01, 0.05],
         permutations=999
     ).to_dataframe()
 
-    power_vec = result_1["effect_size"].to_list()
-    power_vec_sorted = sorted(power_vec)
-
-    assert power_vec == power_vec_sorted
+    for alpha, _df in result_1.groupby("alpha"):
+        power_vec = _df["effect_size"].to_list()
+        power_vec_sorted = sorted(power_vec)
+        assert power_vec == power_vec_sorted

--- a/evident/tests/test_permanova.py
+++ b/evident/tests/test_permanova.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+
+def test_permanova(beta_mock):
+    mdh = beta_mock
+    result_1 = mdh.calculate_effect_size("classification", permanova=True)
+    result_2 = mdh.calculate_effect_size("cd_behavior", permanova=True)
+
+    exp_1 = 0.074407
+    np.testing.assert_approx_equal(exp_1, result_1.effect_size, 5)
+
+    exp_2 = 0.081102
+    np.testing.assert_approx_equal(exp_2, result_2.effect_size, 5)

--- a/evident/tests/test_utils.py
+++ b/evident/tests/test_utils.py
@@ -38,3 +38,32 @@ def test_check_sample_overlap():
         "common to both."
     )
     assert warn_info[0].message.args[0] == exp_msg
+
+
+def test_check_total_obs():
+    md = pd.DataFrame.from_dict({
+        "a": [1, 2, 3, 4, 5, 6],
+        "b": ["A", "A", "B", "B", "C", "C"]
+    })
+    md.index = [f"S{i+1}" for i in range(len(md))]
+
+    args = (md, "b")
+
+    utils._check_total_observations(*args, 10.0)
+    with pytest.raises(ValueError) as exc_info:
+        utils._check_total_observations(*args, 3.5)
+    exp_err_msg = "total_observations must be an integer!"
+    assert str(exc_info.value) == exp_err_msg
+
+    with pytest.raises(ValueError) as exc_info:
+        utils._check_total_observations(*args, 2)
+    exp_err_msg = (
+        "total_observations must be greater than the number of groups!"
+    )
+    assert str(exc_info.value) == exp_err_msg
+
+    exp_err_msg = "total_observations must be positive!"
+    with pytest.raises(ValueError) as exc_info:
+        for i in [0, -1]:
+            utils._check_total_observations(*args, i)
+            assert str(exc_info.value) == exp_err_msg

--- a/evident/utils.py
+++ b/evident/utils.py
@@ -47,3 +47,22 @@ def _preprocess_input(
     distances = squareform(dm.values, force="tovector", checks=False)
 
     return sample_size, num_groups, grouping, tri_idxs, distances
+
+
+def _check_total_observations(
+    metadata: pd.DataFrame,
+    column: str,
+    total_observations: int
+):
+    if not isinstance(total_observations, int):
+        if total_observations % 1 != 0:  # 10.0 should work - check fraction
+            raise ValueError("total_observations must be an integer!")
+    if total_observations <= 0:
+        raise ValueError("total_observations must be positive!")
+
+    num_groups = len(metadata[column].unique())
+
+    if total_observations < num_groups:
+        raise ValueError(
+            "total_observations must be greater than the number of groups!"
+        )

--- a/evident/utils.py
+++ b/evident/utils.py
@@ -30,14 +30,10 @@ def _preprocess_input(
     metadata: pd.DataFrame,
     column: str
 ):
-    """Compute intermediate results not affected by permutations.
-    These intermediate results can be computed a single time for efficiency,
-    regardless of grouping vector permutations (i.e., when calculating the
-    p-value). These intermediate results are used by both ANOSIM and PERMANOVA.
-    Also validates and normalizes input (e.g., converting ``DataFrame`` column
-    into grouping vector).
+    """Compute intermediate PERMANOVA results not affected by permutations.
 
-    Adapted from scikit-bio
+    This function is adapted from scikit-bio under the BSD-3 license.
+    Original code: https://tinyurl.com/3bwu8h9n
     """
     dm = distance_matrix.loc[metadata.index, metadata.index]
     grouping = metadata[column].to_list()

--- a/evident/utils.py
+++ b/evident/utils.py
@@ -1,6 +1,10 @@
 from typing import Any, Iterable
 from warnings import warn
 
+import numpy as np
+import pandas as pd
+from scipy.spatial.distance import squareform
+
 
 def _listify(x: Any):
     """Convert value to list if it is not already iterable."""
@@ -19,3 +23,31 @@ def _check_sample_overlap(ids1: set, ids2: set):
         )
         warn(msg)
     return list(overlap)
+
+
+def _preprocess_input(
+    distance_matrix: pd.DataFrame,
+    metadata: pd.DataFrame,
+    column: str
+):
+    """Compute intermediate results not affected by permutations.
+    These intermediate results can be computed a single time for efficiency,
+    regardless of grouping vector permutations (i.e., when calculating the
+    p-value). These intermediate results are used by both ANOSIM and PERMANOVA.
+    Also validates and normalizes input (e.g., converting ``DataFrame`` column
+    into grouping vector).
+
+    Adapted from scikit-bio
+    """
+    dm = distance_matrix.loc[metadata.index, metadata.index]
+    grouping = metadata[column].to_list()
+    sample_size = dm.shape[0]
+
+    # Find the group labels and convert grouping to an integer vector
+    # (factor).
+    groups, grouping = np.unique(grouping, return_inverse=True)
+    num_groups = len(groups)
+    tri_idxs = np.triu_indices(sample_size, k=1)
+    distances = squareform(dm.values, force="tovector", checks=False)
+
+    return sample_size, num_groups, grouping, tri_idxs, distances


### PR DESCRIPTION
Now allows calculation of PERMANOVA effect sizes (omega-squared) for `MultivariateDataHandler` instances. Math according to https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4514928/ (cite in paper)

At the moment does not allow for calculation of power analysis from this effect size because the effect size is *not* F-distributed (same reason why PERMANOVA uses *pseudo*-F). @wasade do you think this is a critical missing component? Evident is set up to calculate power analytically and this will likely require some sort of involved simulation procedure.

See https://www.frontiersin.org/articles/10.3389/fmicb.2021.796025/full as well